### PR TITLE
Fix for issue where curranking would be float, yielding an error at np.bincount in recovery.rcc2d()

### DIFF
--- a/src/ctxcore/recovery.py
+++ b/src/ctxcore/recovery.py
@@ -77,7 +77,7 @@ def rcc2d(rankings: np.ndarray, weights: np.ndarray, rank_threshold: int) -> np.
     for row_idx in range(n_features):
         curranking = rankings[row_idx, :]
         rccs[row_idx, :] = np.cumsum(
-            np.bincount(curranking, weights=weights)[:rank_threshold]
+            np.bincount(curranking.astype(int), weights=weights)[:rank_threshold]
         )
     return rccs
 


### PR DESCRIPTION
I ran into an issue in pyscenic, where some values for pyscenic.prune.prun2df arguments auc_threshold and nes_threshold, it gave the following error:

```
File "/home/jberkh/miniconda3/envs/envScenic/lib/python3.10/site-packages/ctxcore/recovery.py", line 80, in rcc2d
    np.bincount(curranking, weights=weights)[:rank_threshold]
TypeError: Cannot cast array data from dtype('float64') to dtype('int64') according to the rule 'safe'
```

The error arises from the need for an integer matrix as input for np.bincount. Apparently, curranking becomes a float matrix at certain values for auc_threshold and nes_threshold. The explicit cast to int fixes this issue. 

NB: I'm unsure if the broader context of the code would necessitate calling np.rint() before casting to int. If so, please edit the PR where necessary. 