### PR TITLE
chore: document attrs and setuptools dependencies in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs
 cytoolz
 frozendict
 numba>=0.51.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ numpy
 pandas>=0.24
 pyarrow>=8.0.0
 pyyaml
+setuptools
 tqdm


### PR DESCRIPTION
The code uses `import attr`:
https://github.com/search?q=repo%3Aaertslab%2Fctxcore+attr&type=code

And from the syntax (for example `attr.s` and `attr.ib()`), I conclude that this must be using the `attrs` python package, see for example: https://www.attrs.org/en/stable/api-attr.html#attr.ib

This came up, because this dependency is also missing from the bioconda package and [caused a `ModuleNotFoundError: No module named 'attr'` error in a downstream package](https://github.com/bioconda/bioconda-recipes/actions/runs/19262708208/job/55181204294?pr=60625#step:10:904). I'll also go and fix this there.

If I'm wrong with the package dependency, please correct me!