### PR TITLE
Fix broken setuptools pkg_resources with importlib.metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+attrs
 cytoolz
 diptest
 frozendict
@@ -6,6 +7,7 @@ numpy
 pandas>=0.24
 pyarrow>=8.0.0
 pyyaml
+setuptools
 scipy
 scikit-learn>=0.22.2
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ numpy
 pandas>=0.24
 pyarrow>=8.0.0
 pyyaml
-setuptools
+setuptools>=82
 scipy
 scikit-learn>=0.22.2
 tqdm

--- a/src/ctxcore/__init__.py
+++ b/src/ctxcore/__init__.py
@@ -2,7 +2,7 @@
 
 import contextlib
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
-with contextlib.suppress(DistributionNotFound):
-    __version__ = get_distribution("ctxcore").version
+with contextlib.suppress(PackageNotFoundError):
+    __version__ = version("ctxcore")

--- a/tests/test_featherdb.py
+++ b/tests/test_featherdb.py
@@ -1,15 +1,14 @@
 import pytest
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from ctxcore.genesig import GeneSignature
 from ctxcore.rnkdb import FeatherRankingDatabase as RankingDatabase
 
-TEST_DATABASE_FNAME = resource_filename(
-    "resources.tests",
+TEST_DATABASE_FNAME = str(files("resources.tests").joinpath(
     "hg19-tss-centered-10kb-10species.mc9nr.genes_vs_motifs.rankings.feather",
-)
+))
 TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr.genes_vs_motifs.rankings"
-TEST_SIGNATURE_FNAME = resource_filename("resources.tests", "c6.all.v6.1.symbols.gmt")
+TEST_SIGNATURE_FNAME = str(files("resources.tests").joinpath("c6.all.v6.1.symbols.gmt"))
 
 
 @pytest.fixture

--- a/tests/test_genesig.py
+++ b/tests/test_genesig.py
@@ -1,11 +1,11 @@
 import attr
 import pytest
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from ctxcore.genesig import GeneSignature, Regulon
 
 TEST_SIGNATURE = "msigdb_cancer_c6"
-TEST_SIGNATURE_FNAME = resource_filename("resources.tests", "c6.all.v6.1.symbols.gmt")
+TEST_SIGNATURE_FNAME = str(files("resources.tests").joinpath("c6.all.v6.1.symbols.gmt"))
 
 
 def test_init1() -> None:

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,18 +1,17 @@
 import numpy as np
 import pytest
-from pkg_resources import resource_filename
+from importlib.resources import files
 
 from ctxcore.genesig import GeneSignature
 from ctxcore.recovery import auc1d, rcc2d, weighted_auc1d
 from ctxcore.recovery import enrichment4features as enrichment
 from ctxcore.rnkdb import FeatherRankingDatabase as RankingDatabase
 
-TEST_DATABASE_FNAME = resource_filename(
-    "resources.tests",
+TEST_DATABASE_FNAME = str(files("resources.tests").joinpath(
     "hg19-tss-centered-10kb-10species.mc9nr.genes_vs_motifs.rankings.feather",
-)
+))
 TEST_DATABASE_NAME = "hg19-tss-centered-10kb-10species.mc9nr.genes_vs_motifs.rankings"
-TEST_SIGNATURE_FNAME = resource_filename("resources.tests", "c6.all.v6.1.symbols.gmt")
+TEST_SIGNATURE_FNAME = str(files("resources.tests").joinpath("c6.all.v6.1.symbols.gmt"))
 
 
 @pytest.fixture


### PR DESCRIPTION
Hi! I wanted to update all my pyscenic env with a newer version of h5ad, but updating packages broke the ctx import because of setuptools 82. I fixed it in this pull request.